### PR TITLE
Allow passing handler in config to specify custom functionality, other than, or in addition to, removal.

### DIFF
--- a/st-2.1/SlideToRemove.js
+++ b/st-2.1/SlideToRemove.js
@@ -86,7 +86,7 @@ Ext.define('Ext.plugin.SlideToRemove', {
                     if (this.getHandler() == null) {
                         this.getList().getStore().remove(record);
                     } else {
-                        this.getHandler().call();
+                        this.getHandler().call(listElement, element, record, btn);
                     }
                     Ext.Function.createDelayed(function(){
                         this.getList().resumeEvents(false);


### PR DESCRIPTION
Right now, the only use of this plugin is to use the button that slides out to remove an item from the store. There's no ability to provide any custom functionality on the delete button handler. This pull request would add that functionality by allowing the programmer to pass a custom function as a handler attribute on the config object when instantiating the plugin.
